### PR TITLE
Use parse integer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/pg",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/pg",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "pg": "^8.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/pg",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "MOST Web Framework PostgreSQL Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/PostgreSQLAdapter.js
+++ b/src/PostgreSQLAdapter.js
@@ -4,9 +4,12 @@ import { QueryExpression, QueryField, SqlUtils } from '@themost/query';
 import { TraceUtils } from '@themost/common';
 import { PostgreSQLFormatter } from './PostgreSQLFormatter';
 import { sprintf } from 'sprintf-js';
+import { LangUtils } from '@themost/common';
+
+const parseInteger = LangUtils.parseInt;
 
 pg.types.setTypeParser(20, function(val) {
-    return val === null ? null : parseInt(val);
+    return val === null ? null : parseInteger(val);
 });
 
 pg.types.setTypeParser(1700, function(val) {
@@ -376,7 +379,7 @@ class PostgreSQLAdapter {
                         if (err) { return callback.call(self, err); }
                         let value = 1;
                         if (result.length > 0) {
-                            value = parseInt(result[0][attribute]) + 1;
+                            value = parseInteger(result[0][attribute]) + 1;
                         }
                         self.execute('INSERT INTO increment_id(entity, attribute, value) VALUES (?,?,?)', [entity, attribute, value], function (err) {
                             //throw error if any
@@ -388,7 +391,7 @@ class PostgreSQLAdapter {
                 }
                 else {
                     //get new increment value
-                    const value = parseInt(result[0].value) + 1;
+                    const value = parseInteger(result[0].value) + 1;
                     self.execute('UPDATE increment_id SET value=? WHERE id=?', [value, result[0].id], function (err) {
                         //throw error if any
                         if (err) { return callback.call(self, err); }
@@ -434,8 +437,8 @@ class PostgreSQLAdapter {
      * @returns {string}
      */
     formatType(field, format) {
-        const size = parseInt(field.size);
-        const scale = parseInt(field.scale);
+        const size = parseInteger(field.size);
+        const scale = parseInteger(field.scale);
         let s = 'varchar(512) NULL';
         const type = field.type;
         switch (type) {


### PR DESCRIPTION
This PR forces the usage of `@themost/common#LangUtils.parseInteger` instead of `parseInt`